### PR TITLE
Amend input column names from ECDC data

### DIFF
--- a/R/ecdc_data.R
+++ b/R/ecdc_data.R
@@ -84,7 +84,7 @@ ecdc_data <- function() {
                         iso3c='countryterritoryCode',
                         continent='continentExp',
                         population_2019='popData2019')) %>%
-        tidyr::pivot_longer(cols = .data$cases_weekly:.data$deaths_weekly,names_to='subset',values_to = 'count') %>%
+        tidyr::pivot_longer(cols = .data$cases:.data$deaths,names_to='subset',values_to = 'count') %>%
         dplyr::mutate(date=lubridate::dmy(.data$date)) %>%
         dplyr::group_by(.data$location_name,.data$subset) %>%
         dplyr::arrange(.data$date) %>%


### PR DESCRIPTION
`ecdc_data` has been crashing because the column names have shifted from `cases_weekly` and `deaths_weekly` to `cases` and `deaths`. This amends the expected column names inside the function so that it returns.

The data set appears to terminate in mid-December, but it may still be of historical use to some.